### PR TITLE
Feat: 실시간 시세 웹소켓 통신 로직 추가

### DIFF
--- a/pickle-frontend/src/routes/realtime/RealtimePrice.jsx
+++ b/pickle-frontend/src/routes/realtime/RealtimePrice.jsx
@@ -1,0 +1,20 @@
+export default function RealtimePrice() {
+    let ws;
+    ws = new WebSocket('ws://3.34.126.55:8080');
+    ws.onopen = function() {
+        console.log('WebSocket 연결이 열렸습니다.');
+        ws.send(JSON.stringify({ id: "005930" }));
+    };
+    ws.onmessage = function(event) {
+        const data = JSON.parse(event.data);
+        console.log("받은 데이터!!", data);
+    };
+
+    ws.onclose = function(event) {
+        console.log('WebSocket 연결이 닫혔습니다.');
+    };
+
+    return (
+      <div>실시간 시세를 받아오는 페이지</div>
+    )
+  }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가


### 반영 브랜치
ex) feat/realtime-price--PICKLE-70> dev

### 변경 사항
웹소켓 통신을 통해 실시간 시세를 받는 로직을 추가하였습니다. 

### 테스트 결과
<img width="570" alt="image" src="https://github.com/user-attachments/assets/a97071b0-0f5b-453c-b400-5cd8f4d74408">