### PR TITLE
Feat: 실시간 시세 서버 코드 수정

### DIFF
--- a/pickle-frontend/src/routes/realtime/RealtimePrice.jsx
+++ b/pickle-frontend/src/routes/realtime/RealtimePrice.jsx
@@ -1,20 +1,38 @@
-export default function RealtimePrice() {
-    let ws;
-    ws = new WebSocket('ws://3.34.126.55:8080');
-    ws.onopen = function() {
-        console.log('WebSocket 연결이 열렸습니다.');
-        ws.send(JSON.stringify({ id: "005930" }));
-    };
-    ws.onmessage = function(event) {
-        const data = JSON.parse(event.data);
-        console.log("받은 데이터!!", data);
-    };
+import React, { useEffect, useState } from 'react';
 
-    ws.onclose = function(event) {
-        console.log('WebSocket 연결이 닫혔습니다.');
-    };
+export default function RealtimePrice() {
+    const [connections, setConnections] = useState([]);
+
+    useEffect(() => {
+        const wsConnections = [];
+        const stockIds = ["003230", "005930", "000660"];
+
+        stockIds.forEach(id => {
+            const ws = new WebSocket('ws://localhost:3002');
+            ws.onopen = () => {
+                console.log(`WebSocket 연결이 열렸습니다. ID: ${id}`);
+                ws.send(JSON.stringify({ id }));
+            };
+
+            ws.onmessage = (event) => {
+                const data = JSON.parse(event.data);
+                console.log(`받은 데이터!! ID: ${id}`, data);
+            };
+
+            ws.onclose = () => {
+                console.log(`WebSocket 연결이 닫혔습니다. ID: ${id}`);
+                setConnections(prevConnections => prevConnections.filter(conn => conn !== ws));
+            };
+
+            wsConnections.push(ws);
+        });
+        setConnections(wsConnections);
+        return () => {
+            wsConnections.forEach(ws => ws.close());
+        };
+    }, []);
 
     return (
       <div>실시간 시세를 받아오는 페이지</div>
-    )
-  }
+    );
+}


### PR DESCRIPTION
각각의 종목코드별로 데이터를 받을 수 있도록 수정

### PR 타입
- [x] 기능 수정

### 반영 브랜치
feature/realtime-price-PICKLE-70 -> dev
### 변경 사항
각각의 종목코드별로 데이터를 받을 수 있도록 수정하였습니다.

### 테스트 결과
![image](https://github.com/user-attachments/assets/7187594d-269a-4d95-a3ab-3a8ffae4abe5)
